### PR TITLE
Single quote is needed by default from version 1.0

### DIFF
--- a/src/partials-and-include.html
+++ b/src/partials-and-include.html
@@ -51,7 +51,7 @@ flowers:
   - finch
   - sparrow
 ---
-{% include _head.html %}
+{% include '_head.html' %}
     &lt;h1&gt;{{ title }}&lt;/h1&gt;
 
     &lt;ul&gt;
@@ -60,7 +60,7 @@ flowers:
         {% endfor %}
     &lt;/ul&gt;
 
-{% include _foot.html %}
+{% include '_foot.html' %}
 		 </pre class="codeexample">
 
 		 <p>


### PR DESCRIPTION
Kindly refer to https://www.11ty.dev/docs/languages/liquid/#quoted-include-paths